### PR TITLE
Use literally the same loop body for toeArr and toeObj

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -71,15 +71,15 @@ function toeArr<TData>(
 ): readonly TData[] {
   // TODO: would it be faster to rule out duplicates via a set?
   const keys = errors.map((e) => e.path[depth]) as number[];
-  const arr = new Array<TData>(data.length);
-  for (let index = 0, l = data.length; index < l; index++) {
-    const value = data[index];
-    if (keys.includes(index)) {
+  const obj = new Array<TData>(data.length);
+  for (let key = 0, l = data.length; key < l; key++) {
+    const value = data[key];
+    if (keys.includes(key)) {
       if (value == null) {
-        const error = errors.find((e) => e.path[depth] === index);
+        const error = errors.find((e) => e.path[depth] === key);
         // This is where the error is!
-        // arr[index] = value;
-        Object.defineProperty(arr, index, {
+        // obj[key] = value;
+        Object.defineProperty(obj, key, {
           enumerable: true,
           get() {
             throw error;
@@ -87,15 +87,15 @@ function toeArr<TData>(
         });
       } else {
         // Guaranteed to have at least one entry
-        const filteredErrors = errors.filter((e) => e.path[depth] === index);
+        const filteredErrors = errors.filter((e) => e.path[depth] === key);
         // Recurse
-        arr[index] = Array.isArray(value)
-          ? toeArr(value, depth + 1, filteredErrors)
-          : toeObj(value as any, depth + 1, filteredErrors);
+        obj[key] = Array.isArray(value)
+          ? (toeArr(value, depth + 1, filteredErrors) as any)
+          : toeObj(value, depth + 1, filteredErrors);
       }
     } else {
-      arr[index] = value;
+      obj[key] = value;
     }
   }
-  return arr;
+  return obj;
 }


### PR DESCRIPTION
This compresses marginally better.

Note: you might think that splitting this common code into its own function would be a good idea, but here's reasons why we don't do that:

1. That common function would not be monomorphic, since it'd have to handle both arrays / numbers, and objects / strings.
2. The minification of the existing function results in two almost identical blocks, which gzip can compress really well. A new function would require additional code that couldn't compress as effectively.
3. Function calls are not free, keeping the loop local is marginally better for performance.

Interestingly, breaking `data.length` into its own variable actually significantly increases the gzipped bundle size because terser relabels the variables, and then gzip can't compress the identical blocks as well! I tried renaming the variables to single character names to see if that would fix it, but terser renames the variables even if they already had single character names, so it doesn't help.
